### PR TITLE
MISC: Rename the plugin main file to align with our WP.org official slug `penny-black`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ This plugin integrates Woocommerce to Penny Black, to provide the data for, and 
 
 ## Installation
 
+### Quick Install 
+
+The easiest way to install this plugin is to search for it within your Wordpress system, or download the latest from the [Wordpress Plugin Directory](https://wordpress.org/plugins/penny-black/).
+
+
+### Manual build and install
+
 * Download the latest release from the [releases page](https://github.com/pennyblack-io/woocommerce-pennyblack/releases)
-* Extract the zip file and rename the folder to `woocommerce-pennyblack`, removing the version number component.
+* Extract the zip file and rename the folder to `penny-black`, removing the version number component.
 * Inside the folder run `composer install --no-dev`.
-* Create a zip file from the `woocommerce-pennyblack` folder.
+* Create a zip file from the `penny-black` folder.
 * Upload the folder to your WordPress site, either manually to the plugins directory, or via the admin interface on the plugins page.
 * Install the plugin from the WordPress admin panel.
 * Follow the settings link on the plugins page to configure the plugin:
@@ -21,7 +28,7 @@ This plugin integrates Woocommerce to Penny Black, to provide the data for, and 
 
 * If a new version of the Penny Black PHP SDK is being used remember to update its version number in `composer.json`, and run `composer update`.
 * Bump the version number in the following 3 files:
-  * `woocommerce-pennyblack.php`
+  * `penny-black.php`
   * `readme.txt`
   * `composer.json`
 * Create a new release on GitHub, with the version number as the tag, and the version number as the title.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pennyblack/woocommerce-pennyblack",
     "type": "wordpress-plugin",
     "description": "Woocommerce plugin to integrate Penny Black for transmitting orders and triggering personalise prints",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "license": "MIT",
     "authors": [
         {

--- a/penny-black.php
+++ b/penny-black.php
@@ -12,7 +12,7 @@
  * WC requires at least: 7.1
  * WC tested up to: 7.3.0
  * Requires PHP: 7.4
- * Version: 1.2.2
+ * Version: 1.2.3
  */
 
 use PennyBlackWoo\PennyBlackPlugin;

--- a/penny-black.php
+++ b/penny-black.php
@@ -5,7 +5,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: Penny Black integration for WooCommerce
- * Plugin Uri: https://github.com/pennyblack-io/woocommerce-pennyblack
+ * Plugin Uri: https://wordpress.org/plugins/penny-black/
  * Description: Integrate with Penny Black to share data to power personalised printing.
  * Author: Penny Black
  * Author URI: https://github.com/pennyblack-io/

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Penny Black integration for WooCommerce ===
-Contributors:
+Contributors: pennyblackengineers
 Tags: woocommerce, Woo, marketing, prints, inserts, personalisation, pennyblack, penny black, analytics
 Requires at least: 6.0
-Tested up to: 6.2
+Tested up to: 6.3.1
 Stable tag: 1.2.2
 Requires PHP: 7.4
 License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pennyblackengineers
 Tags: woocommerce, Woo, marketing, prints, inserts, personalisation, pennyblack, penny black, analytics
 Requires at least: 6.0
 Tested up to: 6.3.1
-Stable tag: 1.2.2
+Stable tag: 1.2.3
 Requires PHP: 7.4
 License: MIT
 License URI: https://github.com/pennyblack-io/woocommerce-pennyblack/blob/main/LICENSE.md

--- a/src/PennyBlackPlugin.php
+++ b/src/PennyBlackPlugin.php
@@ -27,7 +27,7 @@ class PennyBlackPlugin
         $orderHook->initialize();
 
         if (is_admin()) {
-            add_filter('plugin_action_links_woocommerce-pennyblack/woocommerce-pennyblack.php', [$this, "createSettingsLink"]);
+            add_filter('plugin_action_links_penny-black/penny-black.php', [$this, "createSettingsLink"]);
             $orderAdminExtension = new OrderAdminExtension();
             $orderAdminExtension->initialize();
         }
@@ -49,7 +49,7 @@ class PennyBlackPlugin
     public static function getVersion(): string
     {
         if (!isset(self::$VERSION)) {
-            $pluginData = get_file_data(__DIR__ . '/../woocommerce-pennyblack.php', array('Version' => 'Version'), false);
+            $pluginData = get_file_data(__DIR__ . '/../penny-black.php', array('Version' => 'Version'), false);
             self::$VERSION = $pluginData['Version'];
         }
         return self::$VERSION;


### PR DESCRIPTION
- update all instructions
- bump to 1.2.3